### PR TITLE
Added variable-width adjustment

### DIFF
--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -221,8 +221,6 @@ namespace ClassicVolumeMixer
 
         private delegate bool EnumedWindow(IntPtr handleWindow, ArrayList handles);
 
-        private IntPtr scrollHandle;
-
         private void openClassicMixer()
         {
             this.process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -4,9 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using static ClassicVolumeMixer.Form1;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.TextBox;
-using System.Windows.Input;
+using System.Collections;
 
 namespace ClassicVolumeMixer
 {
@@ -22,6 +20,7 @@ namespace ClassicVolumeMixer
         private ToolStripMenuItem openClassic = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem sounds = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem closeClick = new System.Windows.Forms.ToolStripMenuItem();
+        private ToolStripMenuItem adjustWidth = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem exit = new System.Windows.Forms.ToolStripMenuItem();
         private Process process;
         private Timer timer = new Timer();
@@ -63,6 +62,7 @@ namespace ClassicVolumeMixer
                      openClassic,
                      sounds,
                      closeClick,
+                     adjustWidth,
                      exit
             });
 
@@ -76,12 +76,21 @@ namespace ClassicVolumeMixer
             closeClick.Checked = true;
             closeClick.Click += new System.EventHandler(closeClickToggle);
 
+            adjustWidth.Text = "dynamicly adjust window width";
+            adjustWidth.Checked = true;
+            closeClick.Click += new System.EventHandler(adjustWidthToggle);
+
             exit.Text = "Exit";
             exit.Click += new System.EventHandler(exit_Click);
 
             timer.Interval = 100;  //if the Mixer takes too long to close after losing focus lower this value
             timer.Tick += new EventHandler(timer_Tick);
 
+        }
+
+        private void adjustWidthToggle(object sender, EventArgs e)
+        {
+            adjustWidth.Checked = !adjustWidth.Checked;
         }
 
         private void ContextMenu_Closing(object sender, ToolStripDropDownClosingEventArgs e)
@@ -138,6 +147,7 @@ namespace ClassicVolumeMixer
                     {
                         ShowWindowAsync(handle, 1);
                         SetForegroundWindow(handle);
+                        setMixerPositionAndSize();
                         timer.Start();
                     }
                     isVisible = !isVisible;
@@ -179,15 +189,6 @@ namespace ClassicVolumeMixer
         }
 
         [DllImport("user32.dll")]
-        public static extern void SetWindowText(int hWnd, String text);
-
-        [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
-        public static extern IntPtr SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int Y, int cx, int cy, int wFlags);
-
-        [DllImport("user32.dll", EntryPoint = "FindWindow", SetLastError = true)]
-        static extern IntPtr FindWindowByCaption(IntPtr ZeroOnly, string lpWindowName);
-
-        [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool GetWindowRect(IntPtr hwnd, ref Rect rectangle);
 
@@ -200,6 +201,15 @@ namespace ClassicVolumeMixer
         [DllImport("user32.dll")]
         static extern IntPtr GetForegroundWindow();
 
+        [DllImport("user32")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool EnumChildWindows(IntPtr window, EnumedWindow callback, ArrayList lParam);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+
+
+
         [StructLayout(LayoutKind.Sequential)]
         public struct Rect
         {
@@ -208,6 +218,10 @@ namespace ClassicVolumeMixer
             public int Right;       // x position of lower-right corner
             public int Bottom;      // y position of lower-right corner
         }
+
+        private delegate bool EnumedWindow(IntPtr handleWindow, ArrayList handles);
+
+        private IntPtr scrollHandle;
 
         private void openClassicMixer()
         {
@@ -220,14 +234,33 @@ namespace ClassicVolumeMixer
             {
                 while (process.MainWindowHandle == IntPtr.Zero) { } //busy waiting until the window is open
                 this.handle = process.MainWindowHandle;
-                Rect corners = new Rect();
-                if (GetWindowRect(handle, ref corners)) //get window dimensions
-                {
-                    Rectangle screenArea = Screen.PrimaryScreen.WorkingArea;
-                    //set window position to bottom right of the PrimaryScreen
-                    SetWindowPos(handle, 0, screenArea.Width - (corners.Right - corners.Left), screenArea.Height - (corners.Bottom - corners.Top), 0, 0, 0x0041);
-                }
+                setMixerPositionAndSize();
             }
+        }
+
+        //sets the mixers position to bottom right of the PrimaryScreen and adjusts the window width depending on the number of active sound application
+        private void setMixerPositionAndSize()
+        {
+            Rectangle screenArea = Screen.PrimaryScreen.WorkingArea;
+            Rect corners = new Rect();
+            GetWindowRect(handle, ref corners);
+
+            ArrayList windowHandles = new ArrayList();
+            EnumedWindow callBackPtr = GetWindowHandle;
+            EnumChildWindows(handle, callBackPtr, windowHandles);
+            int appCount = 3;
+            if (adjustWidth.Checked)
+            {
+                appCount = (windowHandles.Count - 12) / 7;
+            }
+            GetWindowRect(handle, ref corners);
+            MoveWindow(this.handle, screenArea.Width - (160 + 110 * appCount), screenArea.Height - (corners.Bottom - corners.Top), 160 + 110 * appCount, 350, true);
+        }
+
+        private static bool GetWindowHandle(IntPtr windowHandle, ArrayList windowHandles)
+        {
+            windowHandles.Add(windowHandle);
+            return true;
         }
     }
 }

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -78,7 +78,7 @@ namespace ClassicVolumeMixer
 
             adjustWidth.Text = "dynamicly adjust window width";
             adjustWidth.Checked = true;
-            closeClick.Click += new System.EventHandler(adjustWidthToggle);
+            adjustWidth.Click += new System.EventHandler(adjustWidthToggle);
 
             exit.Text = "Exit";
             exit.Click += new System.EventHandler(exit_Click);

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -24,6 +24,7 @@ namespace ClassicVolumeMixer
         private ToolStripMenuItem exit = new System.Windows.Forms.ToolStripMenuItem();
         private Process process;
         private Timer timer = new Timer();
+        private IntPtr taskbar = IntPtr.Zero;
         Stopwatch stopwatch = Stopwatch.StartNew();
         IntPtr handle; // the handle of the mixer window
         bool isVisible;
@@ -82,6 +83,8 @@ namespace ClassicVolumeMixer
 
             exit.Text = "Exit";
             exit.Click += new System.EventHandler(exit_Click);
+
+            taskbar = FindWindow("Shell_TrayWnd", null);
 
             timer.Interval = 100;  //if the Mixer takes too long to close after losing focus lower this value
             timer.Tick += new EventHandler(timer_Tick);
@@ -180,7 +183,8 @@ namespace ClassicVolumeMixer
 
         private void timer_Tick(object sender, EventArgs e)
         {
-            if ((GetForegroundWindow() != handle) && (stopwatch.ElapsedMilliseconds > 1000) && closeClick.Checked)
+            IntPtr foregroundWindow = GetForegroundWindow();
+            if ((foregroundWindow != handle) && closeClick.Checked && ((stopwatch.ElapsedMilliseconds > 1000) || foregroundWindow != taskbar))
             {
                 ShowWindowAsync(handle, 0);
                 isVisible = false;
@@ -207,6 +211,9 @@ namespace ClassicVolumeMixer
 
         [DllImport("user32.dll", SetLastError = true)]
         internal static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
 
 
 


### PR DESCRIPTION
The mixer now adjusts its width depending on the number of audio apps it displays.
The width is adjusted so that one does not have to scroll to get to the desired application.
This option is active by default and can be be disabled in the right-click menu.

before:
![before1](https://user-images.githubusercontent.com/49717341/220491210-fd3d3f8d-1af4-45d2-a050-d38ced05663d.png)
after:
![after1](https://user-images.githubusercontent.com/49717341/220491251-ece1b7cc-632e-4340-af02-452dd72ae089.png)

before:
![before2](https://user-images.githubusercontent.com/49717341/220491272-846a3303-841f-4e26-91b9-5dc9911844c1.png)
after:
![after2](https://user-images.githubusercontent.com/49717341/220491588-fe77223f-ca25-4c78-9633-3feb1c6afc70.png)

