### PR TITLE
Fix for bug with native mixer when closing by clicking away.

### DIFF
--- a/ClassicVolumeMixer/ClassicVolumeMixer.csproj
+++ b/ClassicVolumeMixer/ClassicVolumeMixer.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -55,7 +55,6 @@ namespace ClassicVolumeMixer
             notifyIcon.Text = "Classic Mixer";
             notifyIcon.Visible = true;
             notifyIcon.MouseClick += new MouseEventHandler(notifyIcon_Click);
-            notifyIcon.MouseMove += new MouseEventHandler(notifyIcon_MouseMove);
             notifyIcon.ContextMenuStrip = contextMenu;
 
             contextMenu.Opening += ContextMenu_Opening;
@@ -126,17 +125,12 @@ namespace ClassicVolumeMixer
             soundProcess.Start();
         }
 
-        private void notifyIcon_MouseMove(object sender, MouseEventArgs e)
-        {
-            stopwatch.Restart();
-        }
-
         private void notifyIcon_Click(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
             {
                 //check if the mixer is currently open. 
-                if (this.process.HasExited)
+                if (this.process.HasExited && stopwatch.ElapsedMilliseconds > 100)
                 {
                     openClassicMixer();
                     isVisible = true;
@@ -149,7 +143,7 @@ namespace ClassicVolumeMixer
                         closeMixer();
                         timer.Stop();
                     }
-                    else
+                    else if (stopwatch.ElapsedMilliseconds > 100)
                     {
                         ShowWindowAsync(handle, 1);
                         SetForegroundWindow(handle);
@@ -187,9 +181,10 @@ namespace ClassicVolumeMixer
         private void timer_Tick(object sender, EventArgs e)
         {
             IntPtr foregroundWindow = GetForegroundWindow();
-            if ((foregroundWindow != handle) && closeClick.Checked && ((stopwatch.ElapsedMilliseconds > 1000) || foregroundWindow != taskbar))
+            if ((foregroundWindow != handle) && closeClick.Checked)
             {
                 closeMixer();
+                stopwatch.Restart();
                 timer.Stop();
             }
         }

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -259,6 +259,7 @@ namespace ClassicVolumeMixer
                 this.handle = process.MainWindowHandle;
                 setMixerPositionAndSize();
             }
+            SetForegroundWindow(this.handle);
         }
 
         //sets the mixers position to bottom right of the PrimaryScreen and adjusts the window width depending on the number of active sound application

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -17,13 +17,13 @@ namespace ClassicVolumeMixer
         private static String WinDir = System.Environment.GetEnvironmentVariable("SystemRoot");  //location of windows installation
         private String mixerPath = WinDir + "\\System32\\sndvol.exe";
         private String soundControlPath = WinDir + "\\System32\\mmsys.cpl";
-        private bool win11 = new ManagementObjectSearcher("SELECT Caption FROM Win32_OperatingSystem").Get().Cast<ManagementObject>().FirstOrDefault().GetPropertyValue("Caption").ToString().Contains("Windows 11");
         private NotifyIcon notifyIcon = new NotifyIcon(new System.ComponentModel.Container());
         private ContextMenuStrip contextMenu = new System.Windows.Forms.ContextMenuStrip();
         private ToolStripMenuItem openClassic = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem sounds = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem closeClick = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem adjustWidth = new System.Windows.Forms.ToolStripMenuItem();
+        private ToolStripMenuItem hideMixer = new System.Windows.Forms.ToolStripMenuItem();
         private ToolStripMenuItem exit = new System.Windows.Forms.ToolStripMenuItem();
         private Process process;
         private Timer timer = new Timer();
@@ -66,8 +66,9 @@ namespace ClassicVolumeMixer
                      sounds,
                      closeClick,
                      adjustWidth,
+                     hideMixer,
                      exit
-            });
+            }) ;
 
             openClassic.Text = "Open Classic Volume Mixer";
             openClassic.Click += new System.EventHandler(openClassic_Click);
@@ -83,6 +84,10 @@ namespace ClassicVolumeMixer
             adjustWidth.Checked = true;
             adjustWidth.Click += new System.EventHandler(adjustWidthToggle);
 
+            hideMixer.Text = "hide mixer instead of closing it";
+            hideMixer.Checked = false;
+            hideMixer.Click += new System.EventHandler(hideMixerToggle);
+
             exit.Text = "Exit";
             exit.Click += new System.EventHandler(exit_Click);
 
@@ -91,6 +96,11 @@ namespace ClassicVolumeMixer
             timer.Interval = 100;  //if the Mixer takes too long to close after losing focus lower this value
             timer.Tick += new EventHandler(timer_Tick);
 
+        }
+
+        private void hideMixerToggle(object sender, EventArgs e)
+        {
+            hideMixer.Checked = !hideMixer.Checked;
         }
 
         private void adjustWidthToggle(object sender, EventArgs e)
@@ -191,7 +201,7 @@ namespace ClassicVolumeMixer
 
         private void closeMixer()
         {
-            if (win11)
+            if (hideMixer.Checked)
             {
                 ShowWindowAsync(handle, 0);
                 isVisible = false;


### PR DESCRIPTION
When closing the volume mixer by clicking away, the volume mixer is not actually closed but is just turned invisible.
This is done because in some cases when opening sndvol you can see it opening in the upper left corner before jumping to the lower right. Just turning the mixer invisible circumvents this issue.
However it seems that Windows 10 and presumable 8 use sndvol for their volume mixer in some capacity.
Because sndvol is invisible, the native volume mixer also seems to be invisible.

This fix kills the sndvol process when clicking away, thus completly closing sndvol, on all Windows versions except Windows 11.
This fixes #16.