### PR TITLE
changed the opend mixer and sound panel to the 64-bit Version if it is available

### DIFF
--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -15,7 +15,7 @@ namespace ClassicVolumeMixer
         // it's better to use the Windows Directory directly, because it can change and no be "Windows".
         // private static String drive = System.Environment.GetEnvironmentVariable("SystemDrive");
         private static String WinDir = System.Environment.GetEnvironmentVariable("SystemRoot");  //location of windows installation
-        private String mixerPath = WinDir + "\\System32\\sndvol.exe";
+        private String mixerPath = WinDir + "\\Sysnative\\sndvol.exe";
         private String controlPanelPath = WinDir + "\\Sysnative\\control";
         private String soundPanelArgument = "mmsys.cpl";
         private NotifyIcon notifyIcon = new NotifyIcon(new System.ComponentModel.Container());

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -16,8 +16,8 @@ namespace ClassicVolumeMixer
         // private static String drive = System.Environment.GetEnvironmentVariable("SystemDrive");
         private static String WinDir = System.Environment.GetEnvironmentVariable("SystemRoot");  //location of windows installation
         private String mixerPath = WinDir + "\\System32\\sndvol.exe";
-        private String ControlPanelPath = WinDir + "\\Sysnative\\control";
-        private String SoundPanelArgument = "mmsys.cpl";
+        private String controlPanelPath = WinDir + "\\Sysnative\\control";
+        private String soundPanelArgument = "mmsys.cpl";
         private NotifyIcon notifyIcon = new NotifyIcon(new System.ComponentModel.Container());
         private ContextMenuStrip contextMenu = new System.Windows.Forms.ContextMenuStrip();
         private ToolStripMenuItem openClassic = new System.Windows.Forms.ToolStripMenuItem();
@@ -131,8 +131,8 @@ namespace ClassicVolumeMixer
         private void openSoundControl(object sender, EventArgs e)
         {
             Process soundProcess = new Process();
-            soundProcess.StartInfo.FileName = ControlPanelPath;
-            soundProcess.StartInfo.Arguments = SoundPanelArgument;
+            soundProcess.StartInfo.FileName = controlPanelPath;
+            soundProcess.StartInfo.Arguments = soundPanelArgument;
             soundProcess.StartInfo.UseShellExecute = true;
             soundProcess.Start();
         }

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -16,7 +16,8 @@ namespace ClassicVolumeMixer
         // private static String drive = System.Environment.GetEnvironmentVariable("SystemDrive");
         private static String WinDir = System.Environment.GetEnvironmentVariable("SystemRoot");  //location of windows installation
         private String mixerPath = WinDir + "\\System32\\sndvol.exe";
-        private String soundControlPath = WinDir + "\\System32\\mmsys.cpl";
+        private String ControlPanelPath = WinDir + "\\Sysnative\\control";
+        private String SoundPanelArgument = "mmsys.cpl";
         private NotifyIcon notifyIcon = new NotifyIcon(new System.ComponentModel.Container());
         private ContextMenuStrip contextMenu = new System.Windows.Forms.ContextMenuStrip();
         private ToolStripMenuItem openClassic = new System.Windows.Forms.ToolStripMenuItem();
@@ -130,7 +131,8 @@ namespace ClassicVolumeMixer
         private void openSoundControl(object sender, EventArgs e)
         {
             Process soundProcess = new Process();
-            soundProcess.StartInfo.FileName = soundControlPath;
+            soundProcess.StartInfo.FileName = ControlPanelPath;
+            soundProcess.StartInfo.Arguments = SoundPanelArgument;
             soundProcess.StartInfo.UseShellExecute = true;
             soundProcess.Start();
         }

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -16,7 +16,7 @@ namespace ClassicVolumeMixer
         // private static String drive = System.Environment.GetEnvironmentVariable("SystemDrive");
         private static String WinDir = System.Environment.GetEnvironmentVariable("SystemRoot");  //location of windows installation
         private String mixerPath = WinDir + "\\Sysnative\\sndvol.exe";
-        private String controlPanelPath = WinDir + "\\Sysnative\\control";
+        private String controlPanelPath = WinDir + "\\Sysnative\\control.exe";
         private String soundPanelArgument = "mmsys.cpl";
         private NotifyIcon notifyIcon = new NotifyIcon(new System.ComponentModel.Container());
         private ContextMenuStrip contextMenu = new System.Windows.Forms.ContextMenuStrip();


### PR DESCRIPTION
The 32 bit Version of the Sound Panel lacks some features that the 64-bit Version provides, so the 64-bit Version should be used if available. 

32-bit:<img width="200" alt="Screenshot 2023-11-16 091518" src="https://github.com/popeen/Classic-Volume-Mixer/assets/49717341/1555116f-66ca-408a-b24e-db0fb83352c5"> 64-bit:<img width="200" alt="Screenshot 2023-11-16 091506" src="https://github.com/popeen/Classic-Volume-Mixer/assets/49717341/c2f8d062-5700-46ea-b2cb-afefc7e8863d">
note the "Enhancement" and the "Spatial Sound" Tabs in the 64-bit Version that the 32-bit Version lacks.

This probably fixes #18. 