### PR TITLE
Fix Bug where settings revert to standart

### DIFF
--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -95,16 +95,6 @@ namespace ClassicVolumeMixer
             notifyIcon.Visible = true;
             notifyIcon.MouseClick += new MouseEventHandler(notifyIcon_Click);
             loadContextMenu();
-
-
-            if (File.Exists(saveFile))
-            {
-                readOptions();
-            }
-            else
-            {
-                writeOptions();
-            }
         }
 
         private void VolumeChangeTimer_tick(object sender, EventArgs e)
@@ -184,7 +174,19 @@ namespace ClassicVolumeMixer
                      adjustWidth,
                      hideMixer,
                      exit
-        });
+            });
+
+            if (File.Exists(saveFile))
+            {
+                readOptions();
+            }
+            else
+            {
+                closeClick.Checked = true;
+                adjustWidth.Checked = true;
+                hideMixer.Checked = false;
+                writeOptions();
+            }
 
             openClassic.Text = "Open Classic Volume Mixer";
             openClassic.Click += new System.EventHandler(openClassic_Click);
@@ -193,15 +195,12 @@ namespace ClassicVolumeMixer
             sounds.Click += new System.EventHandler(openSoundControl);
 
             closeClick.Text = "Close by clicking outside the window";
-            closeClick.Checked = true;
             closeClick.Click += new System.EventHandler(closeClickToggle);
 
             adjustWidth.Text = "Dynamically adjust window width";
-            adjustWidth.Checked = true;
             adjustWidth.Click += new System.EventHandler(adjustWidthToggle);
 
             hideMixer.Text = "Hide mixer instead of closing it";
-            hideMixer.Checked = false;
             hideMixer.Click += new System.EventHandler(hideMixerToggle);
 
             exit.Text = "Exit";

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -187,13 +187,13 @@ namespace ClassicVolumeMixer
 
             openClassic.Text = "Open Classic Volume Mixer";
             openClassic.Click += new System.EventHandler(openClassic_Click);
-            closeClick.Checked = options.closeClick;
 
             sounds.Text = "Sound";
             sounds.Click += new System.EventHandler(openSoundControl);
 
             closeClick.Text = "Close by clicking outside the window";
             closeClick.Click += new System.EventHandler(closeClickToggle);
+            closeClick.Checked = options.closeClick;
 
             adjustWidth.Text = "Dynamically adjust window width";
             adjustWidth.Click += new System.EventHandler(adjustWidthToggle);

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -182,14 +182,12 @@ namespace ClassicVolumeMixer
             }
             else
             {
-                closeClick.Checked = true;
-                adjustWidth.Checked = true;
-                hideMixer.Checked = false;
                 writeOptions();
             }
 
             openClassic.Text = "Open Classic Volume Mixer";
             openClassic.Click += new System.EventHandler(openClassic_Click);
+            closeClick.Checked = options.closeClick;
 
             sounds.Text = "Sound";
             sounds.Click += new System.EventHandler(openSoundControl);
@@ -199,9 +197,11 @@ namespace ClassicVolumeMixer
 
             adjustWidth.Text = "Dynamically adjust window width";
             adjustWidth.Click += new System.EventHandler(adjustWidthToggle);
+            adjustWidth.Checked = options.adjustWidth;
 
             hideMixer.Text = "Hide mixer instead of closing it";
             hideMixer.Click += new System.EventHandler(hideMixerToggle);
+            hideMixer.Checked = options.hideMixer;
 
             exit.Text = "Exit";
             exit.Click += new System.EventHandler(exit_Click);
@@ -222,9 +222,6 @@ namespace ClassicVolumeMixer
         private void readOptions()
         {
             options = JsonSerializer.Deserialize<Options>(File.ReadAllText(saveFile));
-            closeClick.Checked = options.closeClick;
-            adjustWidth.Checked = options.adjustWidth;
-            hideMixer.Checked = options.hideMixer;
         }
 
         /**

--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -95,6 +95,16 @@ namespace ClassicVolumeMixer
             notifyIcon.Visible = true;
             notifyIcon.MouseClick += new MouseEventHandler(notifyIcon_Click);
             loadContextMenu();
+
+
+            if (File.Exists(saveFile))
+            {
+                readOptions();
+            }
+            else
+            {
+                writeOptions();
+            }
         }
 
         private void VolumeChangeTimer_tick(object sender, EventArgs e)
@@ -123,7 +133,8 @@ namespace ClassicVolumeMixer
             }
             catch (Exception e)
             {
-                if (showNoAudioDeviceWarning) {
+                if (showNoAudioDeviceWarning)
+                {
                     showNoAudioDeviceWarning = false;
                     MessageBox.Show("There is no audio device on the system. Classic Volume Mixer will close.", "Classic Volume Mixer", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     Application.Exit();
@@ -174,16 +185,7 @@ namespace ClassicVolumeMixer
                      adjustWidth,
                      hideMixer,
                      exit
-            });
-
-            if (File.Exists(saveFile))
-            {
-                readOptions();
-            }
-            else
-            {
-                writeOptions();
-            }
+        });
 
             openClassic.Text = "Open Classic Volume Mixer";
             openClassic.Click += new System.EventHandler(openClassic_Click);
@@ -192,16 +194,16 @@ namespace ClassicVolumeMixer
             sounds.Click += new System.EventHandler(openSoundControl);
 
             closeClick.Text = "Close by clicking outside the window";
-            closeClick.Click += new System.EventHandler(closeClickToggle);
             closeClick.Checked = options.closeClick;
+            closeClick.Click += new System.EventHandler(closeClickToggle);
 
             adjustWidth.Text = "Dynamically adjust window width";
-            adjustWidth.Click += new System.EventHandler(adjustWidthToggle);
             adjustWidth.Checked = options.adjustWidth;
+            adjustWidth.Click += new System.EventHandler(adjustWidthToggle);
 
             hideMixer.Text = "Hide mixer instead of closing it";
-            hideMixer.Click += new System.EventHandler(hideMixerToggle);
             hideMixer.Checked = options.hideMixer;
+            hideMixer.Click += new System.EventHandler(hideMixerToggle);
 
             exit.Text = "Exit";
             exit.Click += new System.EventHandler(exit_Click);
@@ -222,6 +224,9 @@ namespace ClassicVolumeMixer
         private void readOptions()
         {
             options = JsonSerializer.Deserialize<Options>(File.ReadAllText(saveFile));
+            closeClick.Checked = options.closeClick;
+            adjustWidth.Checked = options.adjustWidth;
+            hideMixer.Checked = options.hideMixer;
         }
 
         /**


### PR DESCRIPTION
There is a bug where the settings revert to the standart whenever `loadContextMenu()`  is called. 
This happens when a Playback or Recording device is plugged in or unplugged. 
Which leads to the settings reverting to standart on startup as new AudioDevices are detected after the programm has already startet. 
To prevent this, the Options are now loaded inside the `loadContextMenu()` function.
This fixes #27.