### PR TITLE
support for taskbar not at the bottom

### DIFF
--- a/ClassicVolumeMixer/Form1.cs
+++ b/ClassicVolumeMixer/Form1.cs
@@ -412,7 +412,23 @@ namespace ClassicVolumeMixer
                 appCount = (windowHandles.Count - 12) / 7;
             }
             WindowHelper.GetWindowRect(handle, ref corners);
-            WindowHelper.MoveWindow(handle, screenArea.Width - (160 + 110 * appCount), screenArea.Height - (corners.Bottom - corners.Top), 160 + 110 * appCount, 350, true);
+            WindowHelper.AppBarData taskbarData = new WindowHelper.AppBarData();
+            WindowHelper.SHAppBarMessage(5, ref taskbarData);
+
+            switch (taskbarData.uEdge)
+            {
+                case WindowHelper.AppBarEdge.Left:
+                    WindowHelper.MoveWindow(handle, taskbarData.rect.Right, screenArea.Height - (corners.Bottom - corners.Top), 160 + 110 * appCount, 350, true);
+                    break;
+                case WindowHelper.AppBarEdge.Top:
+                    WindowHelper.MoveWindow(handle, screenArea.Width - (160 + 110 * appCount), taskbarData.rect.Bottom + 7, 160 + 110 * appCount, 350, true);
+                    break;
+                default:
+                    WindowHelper.MoveWindow(handle, screenArea.Width - (160 + 110 * appCount), screenArea.Height - (corners.Bottom - corners.Top), 160 + 110 * appCount, 350, true);
+                    break;
+            }
+            WindowHelper.GetWindowRect(handle, ref corners);
+            Console.WriteLine(corners.Left + " " + corners.Right + " " + (160 + 110 * appCount));
         }
     }
 }

--- a/ClassicVolumeMixer/Helpers/WindowHelper.cs
+++ b/ClassicVolumeMixer/Helpers/WindowHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Runtime.InteropServices;
+using static ClassicVolumeMixer.Helpers.WindowHelper;
 
 namespace ClassicVolumeMixer.Helpers
 {
@@ -28,6 +29,28 @@ namespace ClassicVolumeMixer.Helpers
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+        [DllImport("shell32.dll", SetLastError = true)]
+        public static extern IntPtr SHAppBarMessage(uint dwMessage, [In] ref AppBarData pData);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct AppBarData
+        {
+            public uint cbSize;
+            public IntPtr hWnd;
+            public uint uCallbackMessage;
+            public AppBarEdge uEdge;
+            public Rect rect;
+            public int lParam;
+        }
+
+        public enum AppBarEdge : uint
+        {
+            Left = 0,
+            Top = 1,
+            Right = 2,
+            Bottom = 3
+        }
 
         public delegate bool EnumedWindow(IntPtr handleWindow, ArrayList handles);
 


### PR DESCRIPTION
Allows for the taskbar to be at the left, right, top or bottom. Supports any thickness.
Tested under Windows 10.
![TaskbarTop](https://github.com/user-attachments/assets/9352fc45-c1e1-42f4-8e54-f5d891a2b3f5)
![TaskbarLeft](https://github.com/user-attachments/assets/c75f03a8-8994-4c1d-bab1-b193d8195053)
![TaskbarLeftThick](https://github.com/user-attachments/assets/826c2e5e-a402-48f7-aa16-ac4497134bba)

this solves #35.